### PR TITLE
feature/#13: 상세위치 포함 글 목록

### DIFF
--- a/posts/views.py
+++ b/posts/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import render
 from rest_framework import viewsets, mixins 
 from .models import Post, Comment, Like
 from .serializers import PostSerializer,  PostListSerializer, CommentSerializer
-from rest_framework.decorators import action
+from rest_framework.decorators import action, api_view
 from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
 from rest_framework import status
@@ -126,6 +126,15 @@ class PostViewSet(viewsets.ModelViewSet):
             post.save(update_fields=["likes_count"])
             return Response({"post_id": post.id, "likes_count": post.likes_count, "is_liked": True}, status=201)
 
+    @action(detail=False, methods=["GET"], url_path="map")
+    def map_posts(self, request):
+        posts_with_location = self.get_queryset().filter(
+            latitude__insull = False,
+            longitude__insull = False
+        )
+        serializer = self.get_serializer(posts_with_location, many=True)
+        return Response(serializer.data)
+    
 class PostCommentViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.RetrieveModelMixin, mixins.UpdateModelMixin, mixins.DestroyModelMixin):
     serializer_class = CommentSerializer
 


### PR DESCRIPTION
merge: feature/#11-map 지도 전용 게시글 목록 API 구현

- 지도 페이지에서 사용할 게시글 목록 API 추가
- PostViewSet에 `/posts/map` GET 메서드 구현 (@action 사용)
- 위도/경도 정보가 있는 게시글만 필터링하여 응답
- PostListSerializer에 latitude, longitude 필드 포함 완료
- 지도에 핀 표시 및 마커 클릭 → 상세 페이지 이동 가능 기반 구성
